### PR TITLE
Expose express 'app' property to allow other servers to configure it as needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,12 @@
 - Added tslint, prettier
 - Upgraded packages. Upgraded Typescript to 3.7.2. Refactored some code.
 - Made Authenticator optional when creating route.
+
+**Release 1.0.0**
+
+- Upgraded all packages.
+- Removed keycloak dependency. Authentication is done using 'home' server.
+
+**Release 1.0.1**
+
+- Expose express 'app' property to allow other servers to configure it as needed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **aos-server-utils**
 
-# _Published Version: 1.0.0_
+# _Published Version: 1.0.1_
 
 Contains utilities such as Custom Errors, Keycloak Wrapper etc which are shared by various projects at [Apconic](http://www.apconic.com).
 

--- a/dist/simple-express-decorators/server.d.ts
+++ b/dist/simple-express-decorators/server.d.ts
@@ -1,11 +1,12 @@
+import { Application } from 'express';
 import { Container } from 'inversify';
 import { Authenticator } from '../authenticator';
 export default class Server {
     private port;
-    private app;
     private httpServer;
     private container;
     private routeManagers;
+    app: Application;
     constructor(port: any, container: Container);
     use(...middleWareFunc: any[]): void;
     createRouter(path: string, authenticator?: Authenticator): void;

--- a/lib/simple-express-decorators/server.ts
+++ b/lib/simple-express-decorators/server.ts
@@ -6,10 +6,10 @@ import { Authenticator } from '../authenticator';
 
 export default class Server {
   private port: any;
-  private app: Application;
   private httpServer: http.Server | null;
   private container: Container;
   private routeManagers: Map<string, RouteManager> = new Map<string, RouteManager>();
+  public app: Application;
 
   constructor(port: any, container: Container) {
     this.port = port;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aos-server-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aos-server-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Apconic server utilities. Contains Custom errors, keycloak auth wrapper etc",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Expose express 'app' property to allow other servers to configure it as needed.